### PR TITLE
🌟

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,14 +54,6 @@ RUN update-locale en_US.UTF-8
 RUN mkdir /root/work
 WORKDIR /root/work
 
-# Install hub
-RUN wget https://github.com/github/hub/releases/download/v2.2.3/hub-linux-amd64-2.2.3.tgz
-RUN tar -xf hub-linux-amd64-2.2.3.tgz
-ENV PATH $PATH:/root/work/hub-linux-amd64-2.2.3/bin
-RUN echo 'alias git=hub' >> ~/.bashrc
-RUN mkdir /root/.config
-ADD hub /root/.config/hub
-
 # Set Git config
 RUN git config --global diff.compactionHeuristic true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,88 @@
+FROM ubuntu:14.04
+
+MAINTAINER Vexus2 <hikaru.tooyama@gmail.com>
+
+RUN apt-get dist-upgrade -y
+
+RUN apt-get update -y && apt-get install -y \
+    autoconf \
+    build-essential \
+    imagemagick \
+    libbz2-dev \
+    libcurl4-openssl-dev \
+    libevent-dev \
+    libffi-dev \
+    libglib2.0-dev \
+    libjpeg-dev \
+    libmagickcore-dev \
+    libmagickwand-dev \
+    libmysqlclient-dev \
+    libncurses-dev \
+    libpq-dev \
+    libreadline-dev \
+    libsqlite3-dev \
+    libssl-dev \
+    libxml2-dev \
+    libxslt-dev \
+    libyaml-dev \
+    wget \
+    zlib1g-dev \
+    python-software-properties \
+    software-properties-common \
+    patchutils \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install git from launchpad maintain repo
+RUN add-apt-repository ppa:git-core/ppa -y && apt-get update -y && apt-get install -y \
+    git \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update -y && apt-get install -y \
+    curl \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update -y && apt-get install -y curl procps && rm -rf /var/lib/apt/lists/*
+
+# Add locales
+RUN locale-gen $(grep '\.UTF-8' /usr/share/i18n/SUPPORTED | awk '{ print $1 }')
+
+# Set default locale
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+
+RUN apt-get update -y && apt-get install -y language-pack-ja
+RUN update-locale en_US.UTF-8
+
+RUN mkdir /root/work
+WORKDIR /root/work
+
+# Install hub
+RUN wget https://github.com/github/hub/releases/download/v2.2.3/hub-linux-amd64-2.2.3.tgz
+RUN tar -xf hub-linux-amd64-2.2.3.tgz
+ENV PATH $PATH:/root/work/hub-linux-amd64-2.2.3/bin
+RUN echo 'alias git=hub' >> ~/.bashrc
+RUN mkdir /root/.config
+ADD hub /root/.config/hub
+
+# Set Git config
+RUN git config --global diff.compactionHeuristic true
+
+# Install Ruby to use ruby script in node. e.g.) to expand glob
+ENV RUBY_MAJOR 2.3
+ENV RUBY_VERSION 2.3.1
+
+# some of ruby's build scripts are written in ruby
+# we purge this later to make sure our final image uses what we just built
+RUN apt-get update -y \
+  && apt-get install -y bison ruby \
+  && rm -rf /var/lib/apt/lists/* \
+  && mkdir -p /usr/src/ruby \
+  && curl -SL "http://cache.ruby-lang.org/pub/ruby/$RUBY_MAJOR/ruby-$RUBY_VERSION.tar.bz2" \
+    | tar -xjC /usr/src/ruby --strip-components=1 \
+  && cd /usr/src/ruby \
+  && autoconf \
+  && ./configure --disable-install-doc \
+  && make -j"$(nproc)" \
+  && apt-get purge -y --auto-remove bison ruby \
+  && make install \
+  && rm -r /usr/src/ruby

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN add-apt-repository ppa:git-core/ppa -y && apt-get update -y && apt-get insta
   && rm -rf /var/lib/apt/lists/*
 
 # Add locales
-RUN locale-gen $(grep '\.UTF-8' /usr/share/i18n/SUPPORTED | awk '{ print $1 }')
+RUN locale-gen en_US.UTF-8
 
 # Set default locale
 ENV LC_ALL en_US.UTF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 
 RUN apt-get dist-upgrade -y
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM ubuntu:14.04
 
-MAINTAINER Vexus2 <hikaru.tooyama@gmail.com>
-
 RUN apt-get dist-upgrade -y
 
 RUN apt-get update -y && apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,18 +28,14 @@ RUN apt-get update -y && apt-get install -y \
     python-software-properties \
     software-properties-common \
     patchutils \
+    curl \
+    procps \
   && rm -rf /var/lib/apt/lists/*
 
 # Install git from launchpad maintain repo
 RUN add-apt-repository ppa:git-core/ppa -y && apt-get update -y && apt-get install -y \
     git \
   && rm -rf /var/lib/apt/lists/*
-
-RUN apt-get update -y && apt-get install -y \
-    curl \
-  && rm -rf /var/lib/apt/lists/*
-
-RUN apt-get update -y && apt-get install -y curl procps && rm -rf /var/lib/apt/lists/*
 
 # Add locales
 RUN locale-gen $(grep '\.UTF-8' /usr/share/i18n/SUPPORTED | awk '{ print $1 }')

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,8 +56,8 @@ WORKDIR /root/work
 RUN git config --global diff.compactionHeuristic true
 
 # Install Ruby to use ruby script in node. e.g.) to expand glob
-ENV RUBY_MAJOR 2.3
-ENV RUBY_VERSION 2.3.1
+ENV RUBY_MAJOR 2.4
+ENV RUBY_VERSION 2.4.1
 
 # some of ruby's build scripts are written in ruby
 # we purge this later to make sure our final image uses what we just built

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM ubuntu:16.04
 
-RUN apt-get dist-upgrade -y
-
-RUN apt-get update -y && apt-get install -y \
+ENV DEBIAN_FRONTEND=noninteractive
+RUN sed -i.bak -e "s%http://archive.ubuntu.com/ubuntu/%http://ftp.jaist.ac.jp/pub/Linux/ubuntu/%g" /etc/apt/sources.list && \
+    apt-get update -y && \
+    apt-get dist-upgrade -y && \
+    apt-get install -y \
     autoconf \
     build-essential \
     imagemagick \

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,10 +43,9 @@ RUN add-apt-repository ppa:git-core/ppa -y && apt-get update -y && apt-get insta
 RUN locale-gen en_US.UTF-8
 
 # Set default locale
-ENV LC_ALL en_US.UTF-8
-ENV LANG en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8
 
-RUN apt-get update -y && apt-get install -y language-pack-ja
 RUN update-locale en_US.UTF-8
 
 RUN mkdir /root/work
@@ -56,8 +55,8 @@ WORKDIR /root/work
 RUN git config --global diff.compactionHeuristic true
 
 # Install Ruby to use ruby script in node. e.g.) to expand glob
-ENV RUBY_MAJOR 2.4
-ENV RUBY_VERSION 2.4.1
+ENV RUBY_MAJOR=2.4 \
+    RUBY_VERSION=2.4.1
 
 # some of ruby's build scripts are written in ruby
 # we purge this later to make sure our final image uses what we just built

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+build:
+	docker build -t quay.io/actcat/buildpack_base:dev .

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 build:
-	docker build -t quay.io/actcat/buildpack_base:dev .
+	docker build -t quay.io/actcat/devon_rex_base:dev .


### PR DESCRIPTION
現行のbuildpackとの差分


- maintainer が消えました(なくていいので)
- `make` で docker build できます
- ubuntu 14.04 から 16.04 になりました
- hub command が消えました
  - Node でしか使っていない
  - このアップデートは、Node には影響しない
- 無駄なlocaleを作っているのをやめました
  - en_US.UTF-8 さえあれば動くはず
  - language-pack-ja も drop したけど、これは要らないはず。
- 色々リファクタしました
- ftp.jaist.ac.jp の mirror を使うようにしました
  - 元々 runner でやってたのをこっちに持ってきました
- Ruby 2.3.1 から 2.4.1 になりました
  - これは、RuboCop などの解析機とrunnerが2.4.1で動くことを意味します。
  - 一応 runner_rubocop を動かしてみたけど、特に問題がなさそうだったので平気だと思う
- このレポジトリ( && quay.io 上に作る予定のレポジトリ)はpublicです
  - 元々 public だったし、秘密情報は特に含まれていない