### PR TITLE
Gem install bundler in the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,3 +74,13 @@ RUN apt-get update -y \
   && apt-get purge -y --auto-remove bison ruby \
   && make install \
   && rm -r /usr/src/ruby
+
+ADD gemrc /usr/local/etc/
+ENV GEM_HOME /usr/local/bundle
+ENV PATH $GEM_HOME/bin:$PATH
+RUN gem install bundler \
+  && bundle config --global path "$GEM_HOME" \
+  && bundle config --global bin "$GEM_HOME/bin"
+
+# don't create ".bundle" in all our apps
+ENV BUNDLE_APP_CONFIG $GEM_HOME

--- a/gemrc
+++ b/gemrc
@@ -1,0 +1,2 @@
+install: --no-document
+update: --no-document


### PR DESCRIPTION
This image should run `gem install bundler` because all runners require `bundler`. But currently bundler is installed by each runners.